### PR TITLE
Prevent spaces in file name

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1783,7 +1783,7 @@ class PlgSystemDebug extends JPlugin
 	{
 		$app    = JFactory::getApplication();
 		$conf   = JFactory::getConfig();
-		$domain = $conf->get('sitename', 'site');
+		$domain = str_replace(' ', '_', $conf->get('sitename', 'site'));
 
 		if ($app->isSite())
 		{


### PR DESCRIPTION
This patch replaces spaces in site name with underscores so that the file name does not contain underscores.