### PR TITLE
Fix Travis for mod_status/helper.php

### DIFF
--- a/administrator/modules/mod_status/helper.php
+++ b/administrator/modules/mod_status/helper.php
@@ -19,7 +19,7 @@ abstract class ModStatusHelper
 	/**
 	 * The count of logged users from the Database.
 	 *
-	 * @param   $admin   boolean  True if we want the backend user.
+	 * @param   boolean  $admin  True if we want the backend user.
 	 *
 	 * @return  integer  The user count
 	 *
@@ -51,7 +51,7 @@ abstract class ModStatusHelper
 	/**
 	 * The count of logged users from the Redis Cache.
 	 *
-	 * @param   $admin   boolean  True if we want the backend user.
+	 * @param   boolean  $admin  True if we want the backend user.
 	 *
 	 * @return  integer  The user count
 	 *
@@ -92,10 +92,9 @@ abstract class ModStatusHelper
 			// @todo: If the try fails $data is not defined here.
 			$results[] = json_decode($data);
 
-			//foreach ($results as $k)
 			foreach ($results as $k => $result)
 			{
-				if ((int)$results[$k]->client_id == $admin)
+				if ((int) $results[$k]->client_id == $admin)
 				{
 					$logged_users++;
 				}
@@ -108,7 +107,7 @@ abstract class ModStatusHelper
 	/**
 	 * The count of logged users.
 	 *
-	 * @param   $admin   boolean  True if we want the backend user.
+	 * @param   boolean  $admin  True if we want the backend user.
 	 *
 	 * @return  integer  The user count
 	 *
@@ -116,7 +115,7 @@ abstract class ModStatusHelper
 	 */
 	public static function getOnlineCount($admin)
 	{
- 			$config  = JFactory::getConfig();
+			$config  = JFactory::getConfig();
 			$handler = $config->get('session_handler', 'none');
 			$results = null;
 
@@ -124,10 +123,10 @@ abstract class ModStatusHelper
 			{
 				case 'database':
 				case 'none':
-					$results = ModStatusHelper::getOnlineCountFromDb($admin);
+					$results = self::getOnlineCountFromDb($admin);
 					break;
 				case 'redis':
-					$results = ModStatusHelper::getOnlineCountFromRedis($admin);
+					$results = self::getOnlineCountFromRedis($admin);
 					break;
 				default:
 					break;


### PR DESCRIPTION
```
FILE: ...vis/build/joomla/joomla-cms/administrator/modules/mod_status/helper.php
--------------------------------------------------------------------------------
FOUND 11 ERROR(S) AFFECTING 8 LINE(S)
--------------------------------------------------------------------------------
  22 | ERROR | Doc comment for var boolean does not match actual variable name
     |       | $admin at position 1
  22 | ERROR | Expected 2 spaces after the longest type
  54 | ERROR | Doc comment for var boolean does not match actual variable name
     |       | $admin at position 1
  54 | ERROR | Expected 2 spaces after the longest type
  95 | ERROR | Please put a space between the // and the start of comment text;
     |       | found "//foreach ($results as $k)"
  98 | ERROR | Cast statements must be followed by a single space; expected
     |       | "(int) $results" but found "(int)$results"
 111 | ERROR | Doc comment for var boolean does not match actual variable name
     |       | $admin at position 1
 111 | ERROR | Expected 2 spaces after the longest type
 119 | ERROR | Tabs must be used to indent lines; spaces are not allowed
 127 | ERROR | Must use "self::" for local static member reference
 130 | ERROR | Must use "self::" for local static member reference
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
```

Travis: https://travis-ci.org/joomla/joomla-cms/jobs/75044598