### PR TITLE
Correct idx_alias_item_id for mysql utf8mb4

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-05-07.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-05-07.sql
@@ -1,8 +1,8 @@
 ALTER TABLE `#__languages` ADD INDEX `idx_published_ordering` (`published`,`ordering`);
-ALTER TABLE `#__session` DROP PRIMARY KEY, ADD PRIMARY KEY (session_id(32));
-ALTER TABLE `#__session` DROP INDEX `time`, ADD INDEX `time` (time(10));
+ALTER TABLE `#__session` DROP PRIMARY KEY, ADD PRIMARY KEY (`session_id`(32));
+ALTER TABLE `#__session` DROP INDEX `time`, ADD INDEX `time` (`time`(10));
 ALTER TABLE `#__template_styles` ADD INDEX `idx_client_id` (`client_id`);
-ALTER TABLE `#__contentitem_tag_map` ADD INDEX `idx_alias_item_id` (`type_alias`,`content_item_id`);
+ALTER TABLE `#__contentitem_tag_map` ADD INDEX `idx_alias_item_id` (`type_alias`(100),`content_item_id`);
 ALTER TABLE `#__extensions` ADD INDEX `idx_type_ordering` (`type`,`ordering`);
 ALTER TABLE `#__menu` ADD INDEX `idx_client_id_published_lft` (`client_id`,`published`,`lft`);
 ALTER TABLE `#__viewlevels` ADD INDEX `idx_ordering_title` (`ordering`,`title`);


### PR DESCRIPTION
Correct index `idx_alias_item_id` of table `#__contentitem_tag_map` for mysql utf8mb4 and add missing name quotes on other indexes with lengths limits for columns.

The index `idx_alias_item_id` might not have lead to an SQL error before with utf8mb4 in case if not in strict session mode, but it would for sure make problems later.

The InnoDB storage engine has a maximum index length of 767 bytes, which is max. 191 characters in utf8mb4, and for consistence with all other indexes we should use max. 100 characters.

The missing quotes I have added are cosmetics only and do not do any harm.

I have tested this PR in phpMyAdmin.