### PR TITLE
Support for sqlsrv

### DIFF
--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -465,4 +465,25 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	{
 		return ' NEWID() ';
 	}
+
+	/**
+	 * Find a value in a varchar used like a set.
+	 *
+	 * Ensure that the value is an integer before passing to the method.
+	 *
+	 * Usage:
+	 * $query->findInSet((int) $parent->id, 'a.assigned_cat_ids')
+	 *
+	 * @param   string  $value  The value to search for.
+	 *
+	 * @param   string  $set    The set of values.
+	 *
+	 * @return  string  Returns the find_in_set() Mysql translation.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function findInSet($value, $set)
+	{
+		return "CHARINDEX(',$value,', ',' + $set + ',') > 0";
+	}
 }


### PR DESCRIPTION
### Summary of Changes

https://msdn.microsoft.com/pl-pl/library/ms186323(v=sql.110).aspx

Below code 
```php
$q = new JDatabaseQuerySqlsrv(JFactory::getDbo());
echo $q->select('*')->from('#__content')->where($q->findInSet('your', 'title'));
``` 
generates query:
```sql
SELECT *
FROM #__content
WHERE CHARINDEX(',your,', ',' + title + ',') > 0
```
I have tested above query in sql server 2008.

This works but I do not like that solution.

IMHO findInSet/find_in_set is not a solution for com_fields.
It should be redesigned and another table map should be created and then use INNER JOIN syntax.