### PR TITLE
Correct spacing and names quoting

### DIFF
--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -539,10 +539,10 @@ CREATE NONCLUSTERED INDEX "idx_xreference" ON "#__content"
   "xreference" ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-CREATE NONCLUSTERED INDEX [idx_alias] ON [#__content]
+CREATE NONCLUSTERED INDEX "idx_alias" ON "#__content"
 (
-	[alias] ASC
-)WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+  "alias" ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
 --
 -- Table structure for table `#__content_frontpage`


### PR DESCRIPTION
Synchronized spaces and names quoting to other SQL in this file.

Obviously in joomla.sql for sqlazure, the names quoting is different to the schema updates.

The reason could be that the installation uses a session parameter which allows to use double quotes instead of squared brackets ("[" and "]") for names quoting.

This PR makes the newly added statements use same quoting as the others in this file, and it also fixes spacing so it looks better.