### PR TITLE
Add schema updates and sample data

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.3-2017-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.3-2017-06-25.sql
@@ -1,0 +1,2 @@
+INSERT IGNORE INTO `#__menu_types` (`asset_id`, `menutype`, `title`, `description`, `client_id`)
+VALUES (0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.3-2017-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.3-2017-06-25.sql
@@ -1,2 +1,2 @@
-INSERT IGNORE INTO `#__menu_types` (`asset_id`, `menutype`, `title`, `description`, `client_id`)
+INSERT INTO `#__menu_types` (`asset_id`, `menutype`, `title`, `description`, `client_id`)
 VALUES (0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.3-2017-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.3-2017-06-25.sql
@@ -1,0 +1,2 @@
+INSERT IGNORE INTO "#__menu_types" ("asset_id", "menutype", "title", "description", "client_id")
+VALUES (0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.3-2017-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.3-2017-06-25.sql
@@ -1,2 +1,2 @@
-INSERT IGNORE INTO "#__menu_types" ("asset_id", "menutype", "title", "description", "client_id")
+INSERT INTO "#__menu_types" ("asset_id", "menutype", "title", "description", "client_id")
 VALUES (0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.3-2017-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.3-2017-06-25.sql
@@ -1,2 +1,2 @@
-INSERT IGNORE INTO [#__menu_types] ([asset_id], [menutype], [title], [description], [client_id])
+INSERT INTO [#__menu_types] ([asset_id], [menutype], [title], [description], [client_id])
 VALUES (0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.3-2017-06-25.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.3-2017-06-25.sql
@@ -1,0 +1,2 @@
+INSERT IGNORE INTO [#__menu_types] ([asset_id], [menutype], [title], [description], [client_id])
+VALUES (0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);

--- a/installation/sql/mysql/sample_blog.sql
+++ b/installation/sql/mysql/sample_blog.sql
@@ -132,9 +132,9 @@ INSERT INTO `#__menu` (`id`, `menutype`, `title`, `alias`, `note`, `path`, `link
 
 INSERT INTO `#__menu_types` (`id`, `asset_id`, `menutype`, `title`, `description`, `client_id`) VALUES
 (1, 0, 'mainmenu', 'Main Menu', 'The main menu for the site', 0),
-(2, 0, 'authormenu', 'Author Menu', '', 0),
-(3, 0, 'bottommenu', 'Bottom Menu', '', 0),
-(4, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'authormenu', 'Author Menu', '', 0),
+(4, 0, 'bottommenu', 'Bottom Menu', '', 0);
 
 --
 -- Dumping data for table `#__modules`

--- a/installation/sql/mysql/sample_data.sql
+++ b/installation/sql/mysql/sample_data.sql
@@ -132,8 +132,8 @@ INSERT INTO `#__menu` (`id`, `menutype`, `title`, `alias`, `note`, `path`, `link
 
 INSERT INTO `#__menu_types` (`id`, `asset_id`, `menutype`, `title`, `description`, `client_id`) VALUES
 (1, 0, 'mainmenu', 'Main Menu', 'The main menu for the site', 0),
-(2, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
-(3, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0);
 
 --
 -- Dumping data for table `#__modules`

--- a/installation/sql/mysql/sample_learn.sql
+++ b/installation/sql/mysql/sample_learn.sql
@@ -507,13 +507,13 @@ INSERT INTO `#__menu` (`id`, `menutype`, `title`, `alias`, `note`, `path`, `link
 --
 
 INSERT INTO `#__menu_types` (`id`, `asset_id`, `menutype`, `title`, `description`, `client_id`) VALUES
-(2, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
-(3, 0, 'top', 'Top', 'Links for major types of users', 0),
-(4, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
-(5, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
-(6, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
-(7, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0),
-(8, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
+(4, 0, 'top', 'Top', 'Links for major types of users', 0),
+(5, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
+(6, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
+(7, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
+(8, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0);
 
 --
 -- Dumping data for table `#__modules`

--- a/installation/sql/mysql/sample_testing.sql
+++ b/installation/sql/mysql/sample_testing.sql
@@ -527,15 +527,15 @@ INSERT INTO `#__menu` (`id`, `menutype`, `title`, `alias`, `note`, `path`, `link
 --
 
 INSERT INTO `#__menu_types` (`id`, `asset_id`, `menutype`, `title`, `description`, `client_id`) VALUES
-(2, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
-(3, 0, 'top', 'Top', 'Links for major types of users', 0),
-(4, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
-(5, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
-(6, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
-(7, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0),
-(8, 0, 'frontendviews', 'All Front End Views', '', 0),
-(9, 0, 'modules', 'All Modules', '', 0),
-(10, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1)
+(3, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
+(4, 0, 'top', 'Top', 'Links for major types of users', 0),
+(5, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
+(6, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
+(7, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
+(8, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0),
+(9, 0, 'frontendviews', 'All Front End Views', '', 0),
+(10, 0, 'modules', 'All Modules', '', 0);
 
 --
 -- Dumping data for table `#__modules`

--- a/installation/sql/postgresql/sample_blog.sql
+++ b/installation/sql/postgresql/sample_blog.sql
@@ -136,8 +136,9 @@ SELECT setval('#__menu_id_seq', max(id)) FROM "#__menu";
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
 (1, 0, 'mainmenu','Main Menu', 'The main menu for the site', 0),
-(2, 0, 'authormenu', 'Author Menu', '', 0),
-(3, 0, 'bottommenu', 'Bottom Menu', '', 0);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'authormenu', 'Author Menu', '', 0),
+(4, 0, 'bottommenu', 'Bottom Menu', '', 0);
 
 SELECT setval('#__menu_types_id_seq', max(id)) FROM "#__menu_types";
 

--- a/installation/sql/postgresql/sample_brochure.sql
+++ b/installation/sql/postgresql/sample_brochure.sql
@@ -133,7 +133,8 @@ INSERT INTO "#__menu" ("id", "menutype", "title", "alias", "note", "path", "link
 --
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
-(1, 0, 'mainmenu', 'Main Menu', 'The main menu for the site', 0);
+(1, 0, 'mainmenu', 'Main Menu', 'The main menu for the site', 0),
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);
 
 --
 -- Dumping data for table `#__modules`

--- a/installation/sql/postgresql/sample_data.sql
+++ b/installation/sql/postgresql/sample_data.sql
@@ -132,7 +132,8 @@ INSERT INTO "#__menu" ("id", "menutype", "title", "alias", "note", "path", "link
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
 (1, 0, 'mainmenu', 'Main Menu', 'The main menu for the site', 0),
-(2, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0);
 
 SELECT setval('#__menu_id_seq', max(id)) FROM "#__menu";
 

--- a/installation/sql/postgresql/sample_learn.sql
+++ b/installation/sql/postgresql/sample_learn.sql
@@ -517,12 +517,13 @@ SELECT setval('#__menu_id_seq', max(id)) FROM "#__menu";
 --
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
-(2, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
-(3, 0, 'top', 'Top', 'Links for major types of users', 0),
-(4, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
-(5, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
-(6, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
-(7, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
+(4, 0, 'top', 'Top', 'Links for major types of users', 0),
+(5, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
+(6, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
+(7, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
+(8, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0);
 
 SELECT setval('#__menu_types_id_seq', max(id)) FROM "#__menu_types";
 

--- a/installation/sql/postgresql/sample_testing.sql
+++ b/installation/sql/postgresql/sample_testing.sql
@@ -537,14 +537,15 @@ SELECT setval('#__menu_id_seq', max(id)) FROM "#__menu";
 --
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
-(2, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
-(3, 0, 'top', 'Top', 'Links for major types of users', 0),
-(4, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
-(5, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
-(6, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
-(7, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0),
-(8, 0, 'frontendviews', 'All Front End Views', '', 0),
-(9, 0, 'modules', 'All Modules', '', 0);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
+(4, 0, 'top', 'Top', 'Links for major types of users', 0),
+(5, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
+(6, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
+(7, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
+(8, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0),
+(9, 0, 'frontendviews', 'All Front End Views', '', 0),
+(10, 0, 'modules', 'All Modules', '', 0);
 
 SELECT setval('#__menu_types_id_seq', max(id)) FROM "#__menu_types";
 

--- a/installation/sql/sqlazure/sample_blog.sql
+++ b/installation/sql/sqlazure/sample_blog.sql
@@ -146,8 +146,9 @@ SET IDENTITY_INSERT "#__menu_types" ON;
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
 (1, 0, 'mainmenu','Main Menu', 'The main menu for the site', 0),
-(2, 0, 'authormenu', 'Author Menu', '', 0),
-(3, 0, 'bottommenu', 'Bottom Menu', '', 0);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'authormenu', 'Author Menu', '', 0),
+(4, 0, 'bottommenu', 'Bottom Menu', '', 0);
 
 SET IDENTITY_INSERT "#__menu_types" OFF;
 

--- a/installation/sql/sqlazure/sample_brochure.sql
+++ b/installation/sql/sqlazure/sample_brochure.sql
@@ -155,7 +155,8 @@ SET IDENTITY_INSERT "#__menu" OFF;
 SET IDENTITY_INSERT "#__menu_types" ON;
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
-(1, 0, 'mainmenu', 'Main Menu', 'The main menu for the site', 0);
+(1, 0, 'mainmenu', 'Main Menu', 'The main menu for the site', 0),
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1);
 
 SET IDENTITY_INSERT "#__menu_types" OFF;
 

--- a/installation/sql/sqlazure/sample_data.sql
+++ b/installation/sql/sqlazure/sample_data.sql
@@ -142,7 +142,8 @@ SET IDENTITY_INSERT "#__menu_types" ON;
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
 (1, 0, 'mainmenu', 'Main Menu', 'The main menu for the site', 0),
-(2, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0);
 
 SET IDENTITY_INSERT "#__menu_types" OFF;
 

--- a/installation/sql/sqlazure/sample_learn.sql
+++ b/installation/sql/sqlazure/sample_learn.sql
@@ -533,12 +533,13 @@ SET IDENTITY_INSERT "#__menu" OFF;
 SET IDENTITY_INSERT "#__menu_types" ON;
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
-(2, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
-(3, 0, 'top', 'Top', 'Links for major types of users', 0),
-(4, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
-(5, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
-(6, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
-(7, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
+(4, 0, 'top', 'Top', 'Links for major types of users', 0),
+(5, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
+(6, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
+(7, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
+(8, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0);
 
 SET IDENTITY_INSERT "#__menu_types" OFF;
 

--- a/installation/sql/sqlazure/sample_testing.sql
+++ b/installation/sql/sqlazure/sample_testing.sql
@@ -552,14 +552,15 @@ SET IDENTITY_INSERT "#__menu" OFF;
 SET IDENTITY_INSERT "#__menu_types" ON;
 
 INSERT INTO "#__menu_types" ("id", "asset_id", "menutype", "title", "description", "client_id") VALUES
-(2, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
-(3, 0, 'top', 'Top', 'Links for major types of users', 0),
-(4, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
-(5, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
-(6, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
-(7, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0),
-(8, 0, 'frontendviews', 'All Front End Views', '', 0),
-(9, 0, 'modules', 'All Modules', '', 0);
+(2, 0, 'main', 'Admin Main Menu', 'The main menu for the backend', 1),
+(3, 0, 'usermenu', 'User Menu', 'A Menu for logged-in Users', 0),
+(4, 0, 'top', 'Top', 'Links for major types of users', 0),
+(5, 0, 'aboutjoomla', 'About Joomla', 'All about Joomla!', 0),
+(6, 0, 'parks', 'Australian Parks', 'Main menu for a site about Australian parks', 0),
+(7, 0, 'mainmenu', 'Main Menu', 'Simple Home Menu', 0),
+(8, 0, 'fruitshop', 'Fruit Shop', 'Menu for the sample shop site.', 0),
+(9, 0, 'frontendviews', 'All Front End Views', '', 0),
+(10, 0, 'modules', 'All Modules', '', 0);
 
 SET IDENTITY_INSERT "#__menu_types" OFF;
 


### PR DESCRIPTION
Add the missing schema updates - you might very likely have to rename them later because I do not think this PR will make it into 3.7.3, change mysql sample data so the ID of the new menu type is always 2, and add sample data changes also for postgresql and sqlazure.