### PR TITLE
Fix array's values to match previous syntax

### DIFF
--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -23,7 +23,7 @@ class CategoriesHelper
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected static $filters = array();	
-	
+
 	/**
 	 * Configure the Submenu links.
 	 *
@@ -128,8 +128,8 @@ class CategoriesHelper
 			foreach ($langAssociations as $langAssociation)
 			{
 				// Include only published categories with user access
-				$arrId      = explode(':', $langAssociation->id);
-				$assocId[]  = $arrId[0];
+				$arrId     = explode(':', $langAssociation->id);
+				$assocId[] = $arrId[0];
 			}
 
 			$catId = implode(',', $assocId);
@@ -147,7 +147,7 @@ class CategoriesHelper
 
 			foreach ($results as $result)
 			{
-				$associations[$result->language] = $result->id;
+				$associations[$result->language] = $langAssociations[$result->language]->id;
 			}
 
 			static::$filters[$pk] = $associations;


### PR DESCRIPTION
Original:
```
array(2) {
  ["fr-FR"]=>
  string(18) "11:categorie-fr-fr"
  ["es-ES"]=>
  string(18) "12:categoria-es-es"
}
```

After your PR:
```
array(2) {
  ["fr-FR"]=>
  string(2) "11"
  ["es-ES"]=>
  string(2) "12"
}
```

After my PR:
```
array(2) {
  ["fr-FR"]=>
  string(18) "11:categorie-fr-fr"
  ["es-ES"]=>
  string(18) "12:categoria-es-es"
}
```
