### PR TITLE
Correct doc blocks and unit tests

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1768,7 +1768,7 @@ abstract class JDatabaseQuery
 	 * Note: Not all drivers support all units.
 	 *
 	 * @param   string  $date      The db quoted string representation of the date to add to. May be date or datetime.
-	 * @param   string  $interval  The db quoted string representation of the appropriate number of units
+	 * @param   string  $interval  The string representation of the appropriate number of units
 	 * @param   string  $datePart  The part of the date to perform the addition on
 	 *
 	 * @return  string  The string with the appropriate sql for addition of dates

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1767,7 +1767,7 @@ abstract class JDatabaseQuery
 	 * Prefixing the interval with a - (negative sign) will cause subtraction to be used.
 	 * Note: Not all drivers support all units.
 	 *
-	 * @param   string  $date      The db quoted string representation of the date to add to. May be date or datetime.
+	 * @param   string  $date      The db quoted string representation of the date to add to. May be date or datetime
 	 * @param   string  $interval  The string representation of the appropriate number of units
 	 * @param   string  $datePart  The part of the date to perform the addition on
 	 *

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -1767,8 +1767,8 @@ abstract class JDatabaseQuery
 	 * Prefixing the interval with a - (negative sign) will cause subtraction to be used.
 	 * Note: Not all drivers support all units.
 	 *
-	 * @param   mixed   $date      The date to add to. May be date or datetime
-	 * @param   string  $interval  The string representation of the appropriate number of units
+	 * @param   string  $date      The db quoted string representation of the date to add to. May be date or datetime.
+	 * @param   string  $interval  The db quoted string representation of the appropriate number of units
 	 * @param   string  $datePart  The part of the date to perform the addition on
 	 *
 	 * @return  string  The string with the appropriate sql for addition of dates
@@ -1778,7 +1778,7 @@ abstract class JDatabaseQuery
 	 */
 	public function dateAdd($date, $interval, $datePart)
 	{
-		return trim("DATE_ADD(" . $date . ", INTERVAL " . $interval . ' ' . $datePart . ')');
+		return "DATE_ADD(" . $date . ", INTERVAL " . $interval . ' ' . $datePart . ')';
 	}
 
 	/**

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -688,7 +688,7 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 	 * $query->select($query->dateAdd());
 	 * Prefixing the interval with a - (negative sign) will cause subtraction to be used.
 	 *
-	 * @param   datetime  $date      The date to add to
+	 * @param   string    $date      The db quoted string representation of the date to add to
 	 * @param   string    $interval  The string representation of the appropriate number of units
 	 * @param   string    $datePart  The part of the date to perform the addition on
 	 *

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
@@ -1181,9 +1181,9 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	{
 		return array(
 			// Elements: date, interval, datepart, expected
-			'Add date'		=> array('2008-12-31', '1', 'day', "timestamp 2008-12-31 + interval '1 day'"),
-			'Subtract date'	=> array('2008-12-31', '-1', 'day', "timestamp 2008-12-31 - interval '1 day'"),
-			'Add datetime'	=> array('2008-12-31 23:59:59', '1', 'day', "timestamp 2008-12-31 23:59:59 + interval '1 day'"),
+			'Add date'	=> array("'2008-12-31'", "1", "day", "timestamp '2008-12-31' + interval '1 day'"),
+			'Subtract date'	=> array("'2008-12-31'", "-1", "day", "timestamp '2008-12-31' - interval '1 day'"),
+			'Add datetime'	=> array("'2008-12-31 23:59:59'", "1", "day", "timestamp '2008-12-31 23:59:59' + interval '1 day'"),
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -2015,9 +2015,9 @@ class JDatabaseQueryTest extends TestCase
 	{
 		return array(
 			// Elements: date, interval, datepart, expected
-			'Add date'		=> array('2008-12-31', '1', 'DAY', "DATE_ADD(2008-12-31, INTERVAL 1 DAY)"),
-			'Subtract date'	=> array('2008-12-31', '-1', 'DAY', "DATE_ADD(2008-12-31, INTERVAL -1 DAY)"),
-			'Add datetime'	=> array('2008-12-31 23:59:59', '1', 'DAY', "DATE_ADD(2008-12-31 23:59:59, INTERVAL 1 DAY)"),
+			'Add date'	=> array("'2008-12-31'", "1", "DAY", "DATE_ADD('2008-12-31', INTERVAL 1 DAY)"),
+			'Subtract date'	=> array("'2008-12-31'", "-1", "DAY", "DATE_ADD('2008-12-31', INTERVAL -1 DAY)"),
+			'Add datetime'	=> array("'2008-12-31 23:59:59'", "1", "DAY", "DATE_ADD('2008-12-31 23:59:59', INTERVAL 1 DAY)"),
 		);
 	}
 


### PR DESCRIPTION
Correct doc blocks and unit tests so they show that the $date parameter is in fact a db quoted string.