### PR TITLE
Change indexes and update script name

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.11-2019-07-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.11-2019-07-21.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "#__users_email_lower" ON "#__users" (lower("email"));

--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.5-2019-03-24.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.5-2019-03-24.sql
@@ -1,2 +1,0 @@
-DROP INDEX "#__users_email";
-CREATE UNIQUE INDEX "#__users_email_lower" ON "#__users" ((lower("email")));

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -2053,7 +2053,8 @@ CREATE TABLE "#__users" (
 CREATE INDEX "#__users_idx_name" ON "#__users" ("name");
 CREATE INDEX "#__users_idx_block" ON "#__users" ("block");
 CREATE INDEX "#__users_username" ON "#__users" ("username");
-CREATE UNIQUE INDEX "#__users_email_lower" ON "#__users" ((lower("email")));
+CREATE INDEX "#__users_email" ON "#__users" ("email");
+CREATE INDEX "#__users_email_lower" ON "#__users" (lower("email"));
 
 COMMENT ON COLUMN "#__users"."lastResetTime" IS 'Date of last password reset';
 COMMENT ON COLUMN "#__users"."resetCount" IS 'Count of password resets since lastResetTime';


### PR DESCRIPTION
We can add the new index on lowercase for performance, but we can't make it unique.

Up to now, there was also no unique index on the email column.

If duplicate email or not was handled by the PHP.

Now, when your PR will be applied (including mine here), when creating a new user a duplicate lowercase email address will not be allowed anymore, but old users with that still might exist.

Just applying a unique index with a schema update will fail in such case because of old data.

For fixing old users, too, it needs a kind of warning before update that admins have to clean up their user data. Such stuff we can do maybe with 4.0.

Now we could day "ok, but lets make it unique index in database for new installs, i.e. in joomla.sql".

But that's also not consistent what we have now and would result in inconsistent data structures between new installed and updated Joomla.

That's why I suggest you accept this PR and the other one, update your PR to latest staging and then we test it.

P.S.: Schema update has of course to be renamed, too, because of new Joomla releases. This PR here does that, too.