### PR TITLE
Refactor to use full date searches

### DIFF
--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -378,13 +378,26 @@ class UsersModel extends ListModel
 			}
 		}
 
-		// Add filter for registration time ranges select list
+		// Add filter for registration time ranges select list. UI Visitors get a range of predefined
+		// values. API users can do a full range based on ISO8601
 		$range = $this->getState('filter.range');
+		$registrationStart = $this->getState('filter.registrationStart');
+		$registrationEnd = $this->getState('filter.registrationEnd');
 
 		// Apply the range filter.
-		if ($range)
+		if ($range || ($registrationStart && $registrationEnd))
 		{
-			$dates = $this->buildDateRange($range);
+			if ($range)
+			{
+				$dates = $this->buildDateRange($range);
+			}
+			else
+			{
+				$dates = [
+					'dNow'   => $registrationStart,
+					'dStart' => $registrationEnd,
+				];
+			}
 
 			if ($dates['dStart'] !== false)
 			{
@@ -406,13 +419,26 @@ class UsersModel extends ListModel
 			}
 		}
 
-		// Add filter for last visit time ranges select list
+		// Add filter for last visit time ranges select list. UI Visitors get a range of predefined
+		// values. API users can do a full range based on ISO8601
 		$lastvisitrange = $this->getState('filter.lastvisitrange');
+		$lastVisitStart = $this->getState('filter.lastVisitStart');
+		$lastVisitEnd = $this->getState('filter.lastVisitEnd');
 
 		// Apply the range filter.
-		if ($lastvisitrange)
+		if ($lastvisitrange || ($lastVisitStart && $lastVisitEnd))
 		{
-			$dates = $this->buildDateRange($lastvisitrange);
+			if ($lastvisitrange)
+			{
+				$dates = $this->buildDateRange($lastvisitrange);
+			}
+			else
+			{
+				$dates = [
+					'dNow'   => $lastVisitStart,
+					'dStart' => $lastVisitEnd,
+				];
+			}
 
 			if ($dates['dStart'] === false)
 			{


### PR DESCRIPTION
Allows users to do filters on complete date ranges rather than just the limited values available in the UI (that was for the purpose of reducing the amount of dropdowns in searchtools and therefore better UX)

You can specify `registrationDateStart`, `registrationDateEnd`, `lastVisitDateStart` and `lastVisitDateEnd`.

Ensure the UI continues to work as obviously I modified the backend model too