### PR TITLE
Fix help text of GetConfigurationCommand for group parameter

### DIFF
--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -315,7 +315,7 @@ class GetConfigurationCommand extends AbstractCommand
 
 		$help = "The <info>%command.name%</info> Displays the current value of a configuration option
 				\nUsage: <info>php %command.full_name%</info> <option>
-				\nGroup usage: <info>php %command.full_name%</info> --group=<groupname>
+				\nGroup usage: <info>php %command.full_name%</info> --group <groupname>
 				\nAvailable group names: $groupNames";
 
 		$this->setHelp($help);


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/28666#issuecomment-616112930](https://github.com/joomla/joomla-cms/pull/28666#issuecomment-616112930).

### Summary of Changes

Remove the `=` for the `group` parameter in the help text of GetConfigurationCommand.