### PR TITLE
[4.0] [CMS PR 29592] Fix extensions table inserts in update sql scripts, fix semicolon in base.sql for PostgreSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-06-13.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-06-13.sql
@@ -5,5 +5,5 @@ CREATE TABLE IF NOT EXISTS `#__jobs` (
   PRIMARY KEY (`element`, `folder`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
-INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params", `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(0, 'plg_system_scheduler', 'plugin', 'scheduler', 'system', 0, 1, 1, 0, '', '{"timeout":"3","webcron":"0","webcronkey":"mywebcronactivationkey","lastrun":"0","unit":"60","taskid":"0"}',  0, NULL, 0, 0);
+INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `locked`, `manifest_cache`, `params`, `ordering`, `state`) VALUES
+(0, 'plg_system_scheduler', 'plugin', 'scheduler', 'system', 0, 1, 1, 0, 1, '', '{"timeout":"3","webcron":"0","webcronkey":"mywebcronactivationkey","lastrun":"0","unit":"60","taskid":"0"}', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-06-13.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-06-13.sql
@@ -4,5 +4,5 @@ CREATE TABLE IF NOT EXISTS "#__jobs" (
   PRIMARY KEY ("element", "folder")
 );
 
-INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(0, 'plg_system_scheduler', 'plugin', 'scheduler', 'system', 0, 1, 1, 0, '', '{"timeout":"3","webcron":"0","webcronkey":"mywebcronactivationkey","lastrun":"0","unit":"60","taskid":"0"}',  0, NULL, 0, 0);
+INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "locked", "manifest_cache", "params", "ordering", "state") VALUES
+(0, 'plg_system_scheduler', 'plugin', 'scheduler', 'system', 0, 1, 1, 0, 1, '', '{"timeout":"3","webcron":"0","webcronkey":"mywebcronactivationkey","lastrun":"0","unit":"60","taskid":"0"}', 0, 0);

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -369,7 +369,6 @@ INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", 
 (0, 'plg_workflow_notification', 'plugin', 'notification', 'workflow', 0, 1, 1, 0, 1, '', '{}', 0, 0),
 (0, 'plg_content_imagelazyload', 'plugin', 'imagelazyload', 'content', 0, 0, 1, 0, 1, '', '{}', 0, 0),
 (0, 'plg_system_scheduler', 'plugin', 'scheduler', 'system', 0, 1, 1, 0, 1, '', '{"timeout":"3","webcron":"0","webcronkey":"mywebcronactivationkey","lastrun":"0","unit":"60","taskid":"0"}', 0, 0);
-;
 
 -- Templates
 INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "locked", "manifest_cache", "params", "ordering", "state") VALUES


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/29592](https://github.com/joomla/joomla-cms/pull/29592).

### Summary of Changes

- Add missing `locked` column to the insert into extensions table statement in the update SQL and remove checked out user and time columns with default values from the same statement so that the statement is the same as used in base.sql for new installations.
- Remove obsolete semicolon in base.sql for PostgreSQL.

### Testing Instructions

Code review.