### PR TITLE
Patch 117 patch pr 31379

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -326,6 +326,32 @@
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
 		</field>
+
+		<field
+				name="cors_allow_origin"
+				type="text"
+				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL"
+				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC"
+				default="*"
+				showon="cors:1"
+		/>
+
+		<field
+				name="cors_allow_headers"
+				type="text"
+				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL"
+				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC"
+				default="Content-Type,X-Joomla-Token"
+				showon="cors:1"
+		/>
+
+		<field
+				name="cors_allow_methods"
+				type="text"
+				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL"
+				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC"
+				showon="cors:1"
+		/>
 	</fieldset>
 
 	<fieldset name="ftp" label="CONFIG_FTP_SETTINGS_LABEL">

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -326,32 +326,6 @@
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
 		</field>
-
-		<field
-				name="cors_allow_origin"
-				type="text"
-				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL"
-				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC"
-				default="*"
-				showon="cors:1"
-		/>
-
-		<field
-				name="cors_allow_headers"
-				type="text"
-				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL"
-				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC"
-				default="Content-Type,X-Joomla-Token"
-				showon="cors:1"
-		/>
-
-		<field
-				name="cors_allow_methods"
-				type="text"
-				label="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL"
-				description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC"
-				showon="cors:1"
-		/>
 	</fieldset>
 
 	<fieldset name="ftp" label="CONFIG_FTP_SETTINGS_LABEL">

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -713,11 +713,8 @@ class ApplicationModel extends FormModel
 		// Create the new configuration object.
 		$config = new Registry($data);
 
-		// Overwrite webservices cors settings
+		// Overwrite webservices cors setting
 		$app->set('cors', $data['cors']);
-		$app->set('cors_allow_origin', $data['cors_allow_origin']);
-		$app->set('cors_allow_headers', $data['cors_allow_headers']);
-		$app->set('cors_allow_methods', $data['cors_allow_methods']);
 
 		// Overwrite the old FTP credentials with the new ones.
 		$app->set('ftp_enable', $data['ftp_enable']);

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -713,8 +713,11 @@ class ApplicationModel extends FormModel
 		// Create the new configuration object.
 		$config = new Registry($data);
 
-		// Overwrite webservices cors setting
+		// Overwrite webservices cors settings
 		$app->set('cors', $data['cors']);
+		$app->set('cors_allow_origin', $data['cors_allow_origin']);
+		$app->set('cors_allow_headers', $data['cors_allow_headers']);
+		$app->set('cors_allow_methods', $data['cors_allow_methods']);
 
 		// Overwrite the old FTP credentials with the new ones.
 		$app->set('ftp_enable', $data['ftp_enable']);

--- a/administrator/language/en-GB/com_config.ini
+++ b/administrator/language/en-GB/com_config.ini
@@ -228,3 +228,9 @@ JLIB_RULES_SETTING_NOTES_COM_CONFIG="If you change the setting, it will apply to
 
 COM_CONFIG_WEBSERVICES_SETTINGS="Webservices"
 COM_CONFIG_FIELD_WEBSERVICES_CORSOFFF_LABEL="Enable CORS"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL="Access-Control-Allow-Origin"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC="Specifies the origin allowed to access webservices on this site,sent back in response to a preflight request. Default: * (=all)."
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL="Access-Control-Allow-Headers"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC="Specifies the header(s) sent back in response to a preflight request. Default: Content-Type,X-Joomla-Token"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL="Access-Control-Allow-Methods"
+COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC="Specifies the webservice method(s) allowed to access on this site, sent back in response to a preflight request. Default: all methods available for the requested route."

--- a/administrator/language/en-GB/com_config.ini
+++ b/administrator/language/en-GB/com_config.ini
@@ -228,9 +228,3 @@ JLIB_RULES_SETTING_NOTES_COM_CONFIG="If you change the setting, it will apply to
 
 COM_CONFIG_WEBSERVICES_SETTINGS="Webservices"
 COM_CONFIG_FIELD_WEBSERVICES_CORSOFFF_LABEL="Enable CORS"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_LABEL="Access-Control-Allow-Origin"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC="Specifies the origin allowed to access webservices on this site,sent back in response to a preflight request. Default: * (=all)."
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_LABEL="Access-Control-Allow-Headers"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC="Specifies the header(s) sent back in response to a preflight request. Default: Content-Type,X-Joomla-Token"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_LABEL="Access-Control-Allow-Methods"
-COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC="Specifies the webservice method(s) allowed to access on this site, sent back in response to a preflight request. Default: all methods available for the requested route."

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -161,12 +161,16 @@ final class ApiApplication extends CMSApplication
 	{
 		// Set the Joomla! API signature
 		$this->setHeader('X-Powered-By', 'JoomlaAPI/1.0', true);
+
 		$forceCORS = (int) $this->get('cors');
 
 		if ($forceCORS)
 		{
 			// Enable CORS (Cross-origin resource sharing)
-			$this->setHeader('Access-Control-Allow-Origin', $_SERVER['HTTP_ORIGIN'], true);
+			// Obtain allowed CORS origin from Global Settings.
+			// Set to * (=all) if not set.
+			$allowedOrigin = $this->get('cors_allowed_origin', '*');
+			$this->setHeader('Access-Control-Allow-Origin', $allowedOrigin, true);
 			$this->setHeader('Access-Control-Allow-Headers', 'Authorization');
 
 			if (isset($_SERVER['HTTP_ORIGIN']))
@@ -175,27 +179,10 @@ final class ApiApplication extends CMSApplication
 				header("Access-Control-Allow-Origin: {$_SERVER['HTTP_ORIGIN']}");
 				header('Access-Control-Allow-Credentials: true');
 			}
-
-			// Access-Control headers are received during OPTIONS requests (pre-flight)
-			if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS')
-			{
-				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD']))
-				{
-					header("Access-Control-Allow-Methods: GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE, PATCH");
-				}
-
-				if (isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']))
-				{
-					header("Access-Control-Allow-Headers: {$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS']}");
-				}
-
-				exit(0);
-			}
 		}
 
 		// Parent function can be overridden later on for debugging.
 		parent::respond();
-
 	}
 
 	/**
@@ -212,11 +199,11 @@ final class ApiApplication extends CMSApplication
 		// The API application should not need to use a template
 		if ($params)
 		{
-			$template = new \stdClass;
-			$template->template = 'system';
-			$template->params = new Registry;
+			$template              = new \stdClass;
+			$template->template    = 'system';
+			$template->params      = new Registry;
 			$template->inheritable = 0;
-			$template->parent = '';
+			$template->parent      = '';
 
 			return $template;
 		}
@@ -244,10 +231,13 @@ final class ApiApplication extends CMSApplication
 		PluginHelper::importPlugin('webservices');
 		$this->triggerEvent('onBeforeApiRoute', array(&$router, $this));
 		$caught404 = false;
+		$method    = $this->input->getMethod();
 
 		try
 		{
-			$route = $router->parseApiRoute($this->input->getMethod());
+			$this->handlePreflight($method, $router);
+
+			$route = $router->parseApiRoute($method);
 		}
 		catch (RouteNotFoundException $e)
 		{
@@ -325,6 +315,58 @@ final class ApiApplication extends CMSApplication
 				throw new AuthenticationFailed;
 			}
 		}
+	}
+
+	/**
+	 * Handles preflight requests.
+	 *
+	 * @param $method
+	 * @param $router
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 */
+	protected function handlePreflight($method, $router)
+	{
+		// If not an OPTIONS request or CORS is not enabled,
+		// there's nothing useful to do here.
+		if ($method !== 'OPTIONS' || !(int) $this->get('cors'))
+		{
+			return;
+		}
+
+		// Extract routes matching current route from all known routes.
+		$matchingRoutes = $router->getMatchingRoutes();
+
+		// Extract exposed methods from matching routes.
+		$matchingRoutesMethods = array_unique(
+			array_reduce($matchingRoutes, function ($carry, $route) {
+				return array_merge($carry, $route->getMethods());
+			}, [])
+		);
+
+		// Obtain allowed CORS origin from Global Settings.
+		// Set to * (=all) if not set.
+		$allowedOrigin = $this->get('cors_allowed_origin', '*');
+
+		// Obtain allowed CORS headers from Global Settings.
+		// Set to sensible default if not set.
+		$allowedHeaders = $this->get('cors_allowed_headers', 'Content-Type,X-Joomla-Token');
+
+		// Obtain allowed CORS methods from Global Settings.
+		// Set to methods exposed by current route if not set.
+		$allowedMethods = $this->get('cors_allowed_headers', implode(',', $matchingRoutesMethods));
+
+		// No use to go through the regular route handling hassle,
+		// so let's simply output the headers and exit.
+		$this->setHeader('status', '204');
+		$this->setHeader('Access-Control-Allow-Origin', $allowedOrigin);
+		$this->setHeader('Access-Control-Allow-Headers', $allowedHeaders);
+		$this->setHeader('Access-Control-Allow-Methods', $allowedMethods);
+		$this->sendHeaders();
+
+		$this->close();
 	}
 
 	/**

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -87,7 +87,7 @@ class ApiRouter extends Router
 	{
 		$method = strtoupper($method);
 
-		$validMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "TRACE", "PATCH"];
+		$validMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE", "PATCH"];
 
 		if (!\in_array($method, $validMethods))
 		{
@@ -95,51 +95,7 @@ class ApiRouter extends Router
 		}
 
 		// Get the path from the route and remove and leading or trailing slash.
-		$routePath = $this->getRoutePath();
-
-		$query = Uri::getInstance()->getQuery(true);
-
-		// Iterate through all of the known routes looking for a match.
-		foreach ($this->routes as $route)
-		{
-			if (\in_array($method, $route->getMethods()))
-			{
-				if (preg_match($route->getRegex(), ltrim($routePath, '/'), $matches))
-				{
-					// If we have gotten this far then we have a positive match.
-					$vars = $route->getDefaults();
-
-					foreach ($route->getRouteVariables() as $i => $var)
-					{
-						$vars[$var] = $matches[$i + 1];
-					}
-
-					$controller = preg_split("/[.]+/", $route->getController());
-					$vars       = array_merge($vars, $query);
-
-					return [
-						'controller' => $controller[0],
-						'task'       => $controller[1],
-						'vars'       => $vars
-					];
-				}
-			}
-		}
-
-		throw new RouteNotFoundException(sprintf('Unable to handle request for route `%s`.', $path));
-	}
-
-	/**
-	 * Get the path from the route and remove and leading or trailing slash.
-	 *
-	 * @return string
-	 *
-	 * @since 4.0.0
-	 */
-	public function getRoutePath()
-	{
-		// Get the path from the route and remove and leading or trailing slash.
-		$uri  = Uri::getInstance();
+		$uri = Uri::getInstance();
 		$path = urldecode($uri->getPath());
 
 		/**
@@ -162,7 +118,36 @@ class ApiRouter extends Router
 		// Transform the route
 		$path = $this->removeIndexPhpFromPath($path);
 
-		return $path;
+		$query = Uri::getInstance()->getQuery(true);
+
+		// Iterate through all of the known routes looking for a match.
+		foreach ($this->routes as $route)
+		{
+			if (\in_array($method, $route->getMethods()))
+			{
+				if (preg_match($route->getRegex(), ltrim($path, '/'), $matches))
+				{
+					// If we have gotten this far then we have a positive match.
+					$vars = $route->getDefaults();
+
+					foreach ($route->getRouteVariables() as $i => $var)
+					{
+						$vars[$var] = $matches[$i + 1];
+					}
+
+					$controller = preg_split("/[.]+/", $route->getController());
+					$vars       = array_merge($vars, $query);
+
+					return [
+						'controller' => $controller[0],
+						'task'       => $controller[1],
+						'vars'       => $vars
+					];
+				}
+			}
+		}
+
+		throw new RouteNotFoundException(sprintf('Unable to handle request for route `%s`.', $path));
 	}
 
 	/**
@@ -193,22 +178,5 @@ class ApiRouter extends Router
 
 		// Remove the "index.php/" part of the route and return the result.
 		return substr($path, 10);
-	}
-
-	/**
-	 * Extract routes matching current route from all known routes.
-	 *
-	 * @return \Joomla\Router\Route[]
-	 *
-	 * @since 4.0.0
-	 */
-	public function getMatchingRoutes()
-	{
-		$routePath = $this->getRoutePath();
-
-		// Extract routes matching $routePath from all known routes.
-		return array_filter($this->routes, function ($route) use ($routePath) {
-			return preg_match($route->getRegex(), ltrim($routePath, '/'), $matches) === 1;
-		});
 	}
 }

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -87,7 +87,7 @@ class ApiRouter extends Router
 	{
 		$method = strtoupper($method);
 
-		$validMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE", "PATCH"];
+		$validMethods = ["GET", "POST", "PUT", "DELETE", "HEAD", "TRACE", "PATCH"];
 
 		if (!\in_array($method, $validMethods))
 		{
@@ -95,28 +95,7 @@ class ApiRouter extends Router
 		}
 
 		// Get the path from the route and remove and leading or trailing slash.
-		$uri = Uri::getInstance();
-		$path = urldecode($uri->getPath());
-
-		/**
-		 * In some environments (e.g. CLI we can't form a valid base URL). In this case we catch the exception thrown
-		 * by URI and set an empty base URI for further work.
-		 * TODO: This should probably be handled better
-		 */
-		try
-		{
-			$baseUri = Uri::base(true);
-		}
-		catch (\RuntimeException $e)
-		{
-			$baseUri = '';
-		}
-
-		// Remove the base URI path.
-		$path = substr_replace($path, '', 0, \strlen($baseUri));
-
-		// Transform the route
-		$path = $this->removeIndexPhpFromPath($path);
+		$routePath = $this->getRoutePath();
 
 		$query = Uri::getInstance()->getQuery(true);
 
@@ -125,7 +104,7 @@ class ApiRouter extends Router
 		{
 			if (\in_array($method, $route->getMethods()))
 			{
-				if (preg_match($route->getRegex(), ltrim($path, '/'), $matches))
+				if (preg_match($route->getRegex(), ltrim($routePath, '/'), $matches))
 				{
 					// If we have gotten this far then we have a positive match.
 					$vars = $route->getDefaults();
@@ -148,6 +127,42 @@ class ApiRouter extends Router
 		}
 
 		throw new RouteNotFoundException(sprintf('Unable to handle request for route `%s`.', $path));
+	}
+
+	/**
+	 * Get the path from the route and remove and leading or trailing slash.
+	 *
+	 * @return string
+	 *
+	 * @since 4.0.0
+	 */
+	public function getRoutePath()
+	{
+		// Get the path from the route and remove and leading or trailing slash.
+		$uri  = Uri::getInstance();
+		$path = urldecode($uri->getPath());
+
+		/**
+		 * In some environments (e.g. CLI we can't form a valid base URL). In this case we catch the exception thrown
+		 * by URI and set an empty base URI for further work.
+		 * TODO: This should probably be handled better
+		 */
+		try
+		{
+			$baseUri = Uri::base(true);
+		}
+		catch (\RuntimeException $e)
+		{
+			$baseUri = '';
+		}
+
+		// Remove the base URI path.
+		$path = substr_replace($path, '', 0, \strlen($baseUri));
+
+		// Transform the route
+		$path = $this->removeIndexPhpFromPath($path);
+
+		return $path;
 	}
 
 	/**
@@ -178,5 +193,22 @@ class ApiRouter extends Router
 
 		// Remove the "index.php/" part of the route and return the result.
 		return substr($path, 10);
+	}
+
+	/**
+	 * Extract routes matching current route from all known routes.
+	 *
+	 * @return \Joomla\Router\Route[]
+	 *
+	 * @since 4.0.0
+	 */
+	public function getMatchingRoutes()
+	{
+		$routePath = $this->getRoutePath();
+
+		// Extract routes matching $routePath from all known routes.
+		return array_filter($this->routes, function ($route) use ($routePath) {
+			return preg_match($route->getRegex(), ltrim($routePath, '/'), $matches) === 1;
+		});
 	}
 }


### PR DESCRIPTION
### Summary of Changes

- Added global config settings for `Access-Control-Allow-Origin`, `Access-Control-Allow-Headers` and `Access-Control-Allow-Methods`.
- Added preflight handler method to `Joomla\CMS\Application\ApiApplication`.
- Made some changes to  `Joomla\CMS\Application\ApiApplication` and `Joomla\CMS\Router\Router` needed for implementation of  the preflight handler.
- Removed obsolete code from the  `Joomla\CMS\Application\ApiApplication` respond method.