### PR TITLE
[4.2] task start scheduler on friend site via webcron

### DIFF
--- a/administrator/language/en-GB/plg_task_webcronstart.ini
+++ b/administrator/language/en-GB/plg_task_webcronstart.ini
@@ -1,0 +1,11 @@
+; Joomla! Project
+; (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_TASK_WEBCRONSTART="Task - Start WebCron"
+PLG_TASK_WEBCRONSTART_XML_DESCRIPTION="Start the webcron service for the friend site."
+PLG_TASK_WEBCRONSTART_URL_LABEL="Site URL"
+PLG_TASK_WEBCRONSTART_URL_DESC="The URL of the site to start the webcron service for."
+PLG_TASK_WEBCRONSTART_TITLE="WebCron Starter"
+PLG_TASK_WEBCRONSTART_DESC="Starts the WebCron service for the friend site."

--- a/administrator/language/en-GB/plg_task_webcronstart.sys.ini
+++ b/administrator/language/en-GB/plg_task_webcronstart.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_TASK_WEBCRONSTART="Task - Start WebCron"
+PLG_TASK_WEBCRONSTART_XML_DESCRIPTION="Start the webcron service for the friend site."

--- a/plugins/task/webcronstart/services/provider.php
+++ b/plugins/task/webcronstart/services/provider.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Task.webcronstart
+ *
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\Task\Webcronstart\Extension\Webcronstart;
+
+return new class implements ServiceProviderInterface
+{
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function register(Container $container)
+	{
+		$container->set(
+			PluginInterface::class,
+			function (Container $container)
+			{
+				$plugin     = PluginHelper::getPlugin('task', 'webcronstart');
+				$dispatcher = $container->get(DispatcherInterface::class);
+
+				$webcron = new Webcronstart(
+					$dispatcher,
+					(array) $plugin,
+				);
+
+				return $webcron;
+			}
+		);
+	}
+};

--- a/plugins/task/webcronstart/src/extension/Webcronstart.php
+++ b/plugins/task/webcronstart/src/extension/Webcronstart.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @package     Joomla.Plugins
+ * @subpackage  Task.Webcronstart
+ *
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Plugin\Task\Webcronstart\Extension;
+
+// Restrict direct access
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Component\Scheduler\Administrator\Event\ExecuteTaskEvent;
+use Joomla\Component\Scheduler\Administrator\Task\Status as TaskStatus;
+use Joomla\Component\Scheduler\Administrator\Traits\TaskPluginTrait;
+use Joomla\Event\SubscriberInterface;
+use Joomla\CMS\Http\HttpFactory;
+use Joomla\Registry\Registry;
+
+/**
+ * Task plugin with routines that offer to start the scheduler via webcron on a friend site.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class Webcronstart extends CMSPlugin implements SubscriberInterface
+{
+	use TaskPluginTrait;
+
+	/**
+	 * @var string[]
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected const TASKS_MAP = [
+		'start' => [
+			'langConstPrefix' => 'PLG_TASK_WEBCRONSTART',
+			'form'            => 'start_parameters',
+			'method'          => 'webcronStart',
+		],
+	];
+
+	/**
+	 * @var boolean
+	 * @since 4.1.0
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @return string[]
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public static function getSubscribedEvents(): array
+	{
+		return [
+			'onTaskOptionsList'    => 'advertiseRoutines',
+			'onExecuteTask'        => 'standardRoutineHandler',
+			'onContentPrepareForm' => 'enhanceTaskItemForm',
+		];
+	}
+
+	/**
+	 * @param   ExecuteTaskEvent  $event  The onExecuteTask event
+	 *
+	 * @return integer  The exit code
+	 *
+	 * @since __DEPLOY_VERSION__
+	 * @throws RuntimeException
+	 * @throws LogicException
+	 */
+	protected function webcronStart(ExecuteTaskEvent $event): int
+	{
+		//
+		$params = $event->getArgument('params');
+		$response = '';
+		$options  = new Registry;
+		$options->set('Content-Type', 'application/json');
+
+		// Let the request take longer than 300 seconds to avoid timeout issues
+		try
+		{
+			$response = HttpFactory::getHttp($options)->get($params->url, [], 300);
+		}	
+		catch (\Exception $e)
+		{
+			return TaskStatus::KNOCKOUT;
+		}
+
+		if ($response->code !== 200)
+		{
+			return TaskStatus::KNOCKOUT;
+		}
+
+		return TaskStatus::OK;
+	}
+}

--- a/plugins/task/webcronstart/src/extension/forms/start_parameters.xml
+++ b/plugins/task/webcronstart/src/extension/forms/start_parameters.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<form>
+	<fields name="params">
+		<fieldset name="task_params">
+			<field
+					name="url"
+					type="text"
+					label="PLG_TASK_WEBCRONSTART_URL_LABEL"
+					description="PLG_TASK_WEBCRONSTART_URL_DESC"
+					required="true"
+			/>
+			<field
+				name="timeout"
+				type="number"
+				label="COM_SCHEDULER_CONFIG_TASK_TIMEOUT_LABEL"
+				default="300"
+				required="true"
+				min="10"
+				step="1"
+				validate="number"
+				filter="int"
+			/>
+		</fieldset>
+	</fields>
+</form>

--- a/plugins/task/webcronstart/webcronstart.xml
+++ b/plugins/task/webcronstart/webcronstart.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="task" method="upgrade">
+	<name>plg_task_webcronstart</name>
+	<author>Joomla! Project</author>
+	<creationDate>2022-05</creationDate>
+	<copyright>(C) 2020 Open Source Matters, Inc.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>4.0.0</version>
+	<description>PLG_TASK_WEBCRONSTART_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\Task\Webcronstart</namespace>
+	<files>
+		<folder plugin="webcronstart">services</folder>
+		<folder>src</folder>
+	</files>
+	<languages>
+		<language tag="en-GB">language/en-GB/plg_task_webcronstart.ini</language>
+		<language tag="en-GB">language/en-GB/plg_task_webcronstart.sys.ini</language>
+	</languages>
+</extension>


### PR DESCRIPTION
### Summary of Changes
Added a new task to start the scheduler on a friend site via Webcron


### Testing Instructions

apply pr  (on site A)
discover extension and install the new task plugin
enable the  plugin

(on site B) site suppose that doesn't have crontab
enable the webcron
![image](https://user-images.githubusercontent.com/181681/170050394-c6bd0685-ff71-4ccf-bde6-b8e1dc5fc53e.png)
copy the link
enable some task  ie (sleep) for example

on site (A)
create a new task WebCronStarter
![image](https://user-images.githubusercontent.com/181681/170050844-b855dfbd-3608-42cf-89d1-2fd5307ec8c6.png)
and paste the URL copied before from (site B)
run the scheduler from cli for example 
` php cli/joomla.php scheduler:run`

(on site B) 
check that the task have been executed

### Actual result BEFORE applying this Pull Request
N/A


### Expected result AFTER applying this Pull Request
you can schedule a task to start the scheduler on a friend site via webcron


### Documentation Changes Required

