### PR TITLE
[4] Filtering for non-core extensions closes the searchbar

### DIFF
--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -56,6 +56,7 @@ class ManageModel extends InstallerModel
                 'package_id',
                 'extension_id',
                 'creationDate',
+                'core',
             ];
         }
 


### PR DESCRIPTION
Pull Request for Issue #41382

### Summary of Changes
add core to filter


### Testing Instructions
open /administrator/index.php?option=com_installer&view=manage
Select the last filter "non-core extensions"


### Actual result BEFORE applying this Pull Request

page releoad
search bar is closed 

### Expected result AFTER applying this Pull Request

page releoad
search bar is open


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
