### PR TITLE
[CMS PR 46424] Make code more version agnostic

### DIFF
--- a/administrator/modules/mod_backward/src/Dispatcher/Dispatcher.php
+++ b/administrator/modules/mod_backward/src/Dispatcher/Dispatcher.php
@@ -12,6 +12,7 @@ namespace Joomla\Module\Backward\Administrator\Dispatcher;
 
 use Joomla\CMS\Dispatcher\AbstractModuleDispatcher;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Version;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -34,8 +35,8 @@ class Dispatcher extends AbstractModuleDispatcher
     protected function getLayoutData()
     {
         $data               = parent::getLayoutData();
-        $data['compat']     = PluginHelper::isEnabled('behaviour', 'compat');
-        $data['compatNext'] = PluginHelper::isEnabled('behaviour', 'compat6');
+        $data['compat']     = PluginHelper::isEnabled('behaviour', 'compat') ? (string) Version::MAJOR_VERSION : '';
+        $data['compatNext'] = PluginHelper::isEnabled('behaviour', 'compat6') ? (string) (Version::MAJOR_VERSION + 1) : '';
 
         return $data;
     }

--- a/administrator/modules/mod_backward/tmpl/default.php
+++ b/administrator/modules/mod_backward/tmpl/default.php
@@ -13,11 +13,11 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 
 ?>
-<?php if ($compat || $compatNext) : ?>
+<?php if (!empty($compat) || !empty($compatNext)) : ?>
     <div class="header-item-content joomlaversion">
         <div class="header-item-text no-link">
             <span class="icon-shield-alt" aria-hidden="true"></span>
-            <span aria-hidden="true"><?php echo Text::_('MOD_BACKWARD_TEXT') . ($compat ? '5' : '') . ($compat && $compatNext ? ', ' : '') . ($compatNext ? '6' : ''); ?></span>
+            <span aria-hidden="true"><?php echo Text::_('MOD_BACKWARD_TEXT') . $compat . ($compat && $compatNext ? ', ' : '') . $compatNext); ?></span>
         </div>
     </div>
 <?php endif; ?>

--- a/administrator/modules/mod_backward/tmpl/default.php
+++ b/administrator/modules/mod_backward/tmpl/default.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Language\Text;
     <div class="header-item-content joomlaversion">
         <div class="header-item-text no-link">
             <span class="icon-shield-alt" aria-hidden="true"></span>
-            <span aria-hidden="true"><?php echo Text::_('MOD_BACKWARD_TEXT') . $compat . ($compat && $compatNext ? ', ' : '') . $compatNext); ?></span>
+            <span aria-hidden="true"><?php echo Text::_('MOD_BACKWARD_TEXT') . $compat . ((!empty($compat) && !empty($compatNext)) ? ', ' : '') . $compatNext; ?></span>
         </div>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Make code more version agnostic so if doesn't need many changes in 6.x-dev.

The plugin name can also use the major versions in 6.x when we can assume that the plugin names are always with the current major and the nexct major at the end, e.g. compat6 and compat7. Unfortunately the J5 plugin did not follow that rule yet, so we can't do that here now.

## Summary by Sourcery

Make the backward compatibility module display supported major versions dynamically based on the current Joomla major version and plugin availability, improving version agnosticism.

Bug Fixes:
- Ensure the backward compatibility header only renders when compat version values are non-empty, avoiding reliance on truthiness of raw flags.

Enhancements:
- Use Joomla's Version API to derive current and next major version labels when corresponding compatibility plugins are enabled.
- Update the module template to render dynamic major version numbers instead of hardcoded '5' and '6' values.