### PR TITLE
Fix codespaces apache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
     },
     "forwardPorts": [80, 443, 6080, 8025],
     "postCreateCommand": "bash ./.devcontainer/post-create.sh",
+    "postStartCommand": "service apache2 start",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "443:443"
       - "3306:3306"
       - "6080:6080"
-    command: sleep infinity
+    command: apache2-foreground
 
   mysql:
     image: mysql:8.0

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "443:443"
       - "3306:3306"
       - "6080:6080"
-    command: apache2-foreground
+    command: sleep infinity
 
   mysql:
     image: mysql:8.0


### PR DESCRIPTION
### Summary of Changes
This PR provides a stable solution for automatically starting the Apache service upon launching GitHub Codespaces.

- Reverts `command` in `docker-compose.yml` back to `sleep infinity` (or keeps it untouched) to ensure the container's lifecycle is not strictly bound to the Apache process.
- Adds `"postStartCommand": "service apache2 start"` to `.devcontainer/devcontainer.json`.

### Why this approach?
Changing `command` to `apache2-foreground` in `docker-compose.yml` binds the container lifecycle directly to Apache. If Apache exits or reloads, the entire Codespace container shuts down immediately. 

Using `postStartCommand` in `devcontainer.json` seamlessly launches Apache in the background once the devcontainer is ready, keeping the environment completely stable and accessible.

### Testing Instructions
1. Open a new Codespace on this branch.
2. Wait for the environment and post-start hooks to finish.
3. Check the **Ports** tab or access port `80`; Apache will be running in the background without manual commands or container crashes.

<img width="1333" height="490" alt="Screenshot 2026-09-03 084937" src="https://github.com/user-attachments/assets/7d021d39-7cba-4526-b6aa-a2f0349f446b" />

## Summary by Sourcery

Start Apache through the devcontainer startup lifecycle so Codespaces remain stable while serving the application.

New Features:
- Automatically start Apache when a GitHub Codespace finishes launching.

Bug Fixes:
- Prevent Codespace containers from being tied to the Apache process lifecycle.